### PR TITLE
Juliagomes/clean up formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For the off-the-shelf Guards, we have benchmarked results on public datasets.
 We benchmarked the Context Relevancy Guard on "wiki_qa-train" benchmark dataset in `benchmark_context_relevancy_prompt.py`.
 * https://huggingface.co/datasets/microsoft/wiki_qa
 
+```
 Model: gpt-4o-mini
 Guard Results
               precision    recall  f1-score   support
@@ -46,6 +47,7 @@ max       14.102804
 Name: guard_latency_gpt-4o-mini, dtype: float64
 median latency
 2.2489616039965767
+```
 
 ### Hallucination LLM Judge
 
@@ -53,6 +55,7 @@ This Guard was benchmarked on the "halueval_qa_data" from the HaluEval benchmark
 * https://arxiv.org/abs/2305.11747
 * https://github.com/RUCAIBox/HaluEval
 
+```
 Model: gpt-4o-mini
 Guard Results
               precision    recall  f1-score   support
@@ -76,6 +79,7 @@ max        6.403010
 Name: guard_latency_gpt-4o-mini, dtype: float64
 median latency
 1.7582097915001214
+```
 
 ### QA Correctness LLM Judge
 
@@ -93,9 +97,7 @@ Guard Results
     accuracy                           0.98       250
    macro avg       0.98      0.98      0.98       250
 weighted avg       0.98      0.98      0.98       250
-```
 
-```
 Latency
 count    250.000000
 mean       2.610912

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ median latency
 This Guard was benchmarked on the 2.0 version of the large-scale dataset Stanford Question Answering Dataset (SQuAD 2.0):
 https://web.stanford.edu/class/archive/cs/cs224n/cs224n.1194/reports/default/15785042.pdf
 
+```
 Model: gpt-4o-mini
 Guard Results
               precision    recall  f1-score   support
@@ -92,7 +93,9 @@ Guard Results
     accuracy                           0.98       250
    macro avg       0.98      0.98      0.98       250
 weighted avg       0.98      0.98      0.98       250
+```
 
+```
 Latency
 count    250.000000
 mean       2.610912
@@ -105,6 +108,7 @@ max       10.625763
 Name: guard_latency_gpt-4o-mini, dtype: float64
 median latency
 2.263148645986803
+```
 
 ## Installation
 


### PR DESCRIPTION
Fix formatting in README.

Previous version:
<img width="899" alt="Screenshot 2024-08-06 at 12 46 12 PM" src="https://github.com/user-attachments/assets/a42ac9d7-29e6-438f-9321-5d8bd4a0d882">

New version:
<img width="1051" alt="Screenshot 2024-08-06 at 12 46 37 PM" src="https://github.com/user-attachments/assets/56a7711a-b114-4fa6-b548-1a1863b98ce9">
